### PR TITLE
edits made to the docker yml to allow for intentional DB reset

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,9 +36,13 @@ services:
       # This allows live reload inside a docker container by mapping your
       # filesystem to the container's.
       - ./api/src:/code/src
-      # Sleep time added for seeding since things get kinda weird if you don't wait.
-      # To reset database with Admin seeded, change command to "/bin/sh -c "sleep 2 && npm run seed && npm run dev""
-    command: /bin/sh -c "sleep 2 && npm run seed && npm run dev"
+      # Sleep time added for seeding database with Admin user.
+      # To reset database with Admin seeded, run "RESET_DB=true docker-compose up" in terminal.
+    command: /bin/sh -c 'if [ "$RESET_DB" = "true" ]; then
+              sleep 2 && npm run seed && npm run dev;
+            else
+              npm run dev;
+            fi'
 
   app:
     build: ./client


### PR DESCRIPTION
The docker-compose.yml was configured so that any time the application was run on containers, the database would be reset and all tables dropped. Edits were made to the yml file to allow for the programmer to decide whether they want the data in the tables to persist or to be reset, to include an admin account to allow developer access to the application. 